### PR TITLE
freeze layer name rectified

### DIFF
--- a/Downstream/multi-modalities-downstream/CoTrain/modules/clip_module.py
+++ b/Downstream/multi-modalities-downstream/CoTrain/modules/clip_module.py
@@ -322,8 +322,8 @@ class CLIP(pl.LightningModule):
         for n, p in self.named_parameters():
             if (
                 "clip.visual" in n
-                and "clip.visual.ln_post" not in n
-                and "clip.visual.proj" not in n
+                and "clip.visual_ln_post" not in n
+                and "clip.visual_proj" not in n
             ):
                 p.requires_grad = False
             elif "clip.transformer" in n:


### PR DESCRIPTION
Layer name has been changed in [InternVideo/clip_utils/model.py#L268](https://github.com/OpenGVLab/InternVideo/blob/main/Downstream/multi-modalities-downstream/CoTrain/modules/InternVideo/clip_utils/model.py#L268), but the name used in freeze function didn't updated.