### PR TITLE
Fix memory leak.

### DIFF
--- a/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_evl/evl_utils/clip_vit_fusion.py
+++ b/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_evl/evl_utils/clip_vit_fusion.py
@@ -249,7 +249,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_evl/evl_utils/clip_vit_only_global.py
+++ b/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_evl/evl_utils/clip_vit_only_global.py
@@ -224,7 +224,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_kc_new/evl_utils/clip_vit_fusion.py
+++ b/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_kc_new/evl_utils/clip_vit_fusion.py
@@ -249,7 +249,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_kc_new/evl_utils/clip_vit_only_global.py
+++ b/InternVideo1/Downstream/Video-Text-Retrieval/modules/clip_kc_new/evl_utils/clip_vit_only_global.py
@@ -224,7 +224,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Downstream/multi-modalities-downstream/CoTrain/modules/InternVideo/clip_utils/utils/clip_vit_only_global.py
+++ b/InternVideo1/Downstream/multi-modalities-downstream/CoTrain/modules/InternVideo/clip_utils/utils/clip_vit_only_global.py
@@ -224,7 +224,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:].clone()
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Pretrain/Multi-Modalities-Pretraining/InternVideo/clip_utils/utils/clip_vit_only_global.py
+++ b/InternVideo1/Pretrain/Multi-Modalities-Pretraining/InternVideo/clip_utils/utils/clip_vit_only_global.py
@@ -224,7 +224,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats).view(N, C, T_down, L - 1).permute(3, 0, 2, 1)
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # enhancer
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)

--- a/InternVideo1/Pretrain/UniFormerV2/slowfast/models/uniformerv2_model.py
+++ b/InternVideo1/Pretrain/UniFormerV2/slowfast/models/uniformerv2_model.py
@@ -261,7 +261,8 @@ class Transformer(nn.Module):
                 _, tmp_feats = tmp_x[:1], tmp_x[1:]
                 tmp_feats = tmp_feats.permute(1, 3, 2, 0).reshape(N, C, T_down, H, W)
                 tmp_feats = self.dpe[j](tmp_feats.clone()).view(N, C, T_down, L - 1).permute(3, 0, 2, 1).contiguous()
-                tmp_x[1:] = tmp_x[1:] + tmp_feats
+                # tmp_x[1:] = tmp_x[1:] + tmp_feats # memory leak        
+                tmp_x = torch.cat([tmp_x[:1], tmp_x[1:] + tmp_feats], dim=0) # no memory leak
                 # global block
                 tmp_x = tmp_x.permute(2, 0, 1, 3).flatten(0, 1)  # T * L, N, C
                 cls_token = self.dec[j](cls_token, tmp_x)


### PR DESCRIPTION
This is a fix for a memory leak (of a few megabytes per call).
The line
```python
tmp_x[1:] = tmp_x[1:] + tmp_feats
```
creates a reference cycle that the garbage collector is unable to release.

Here is the active memory use before and after the fix (ran 3 epochs of 10 steps).
<img width="380" alt="Screenshot 2024-03-31 at 10 37 58 AM" src="https://github.com/OpenGVLab/InternVideo/assets/5116854/b7799b24-c9d6-4391-8440-26d467948432">
