### PR TITLE
Fix links in README.md

### DIFF
--- a/InternVideo2/multi_modality/README.md
+++ b/InternVideo2/multi_modality/README.md
@@ -19,7 +19,7 @@ We give a short instructions of accessing and utilizing InternVideo2-stage2 in [
 
 ## Pre-Training
 
-We use [InternVL](https://github.com/OpenGVLab/InternVL/) pretrained model as the teacher by default
+We use [InternVL](https://github.com/OpenGVLab/InternVL/) pretrained model as the teacher by default.
 
 For training, you can simply run the pretraining scripts in `scripts/pretraining` as follows:
 ```shell
@@ -51,7 +51,7 @@ bash scripts/pretraining/clip/1B/run.sh
 :warning: **Notes:**
 1. Download [chinese_alpaca_lora_7b](https://github.com/OpenGVLab/InternVL/tree/main/clip_benchmark/clip_benchmark/models/internvl_c_pytorch/chinese_alpaca_lora_7b) and set the `llama_path` and `tokenizer_path` in `config.py`.
 2. Download [InternVideo2-stage2_1b-224p-f4.pt](https://huggingface.co/OpenGVLab/InternVideo2/blob/main/InternVideo2-stage2_1b-224p-f4.pt) and set `vision_ckpt_path` in `config.py`.
-3. Download [internvl_c_13b_224px](https://huggingface.co/OpenGVLab/InternVL/blob/main/internvl_c_13b_224px.pth) and set `text_ckpt_path` in `config.py`, you also need to set ,.
+3. Download [internvl_c_13b_224px](https://huggingface.co/OpenGVLab/InternVL/blob/main/internvl_c_13b_224px.pth) and set `text_ckpt_path` in `config.py`.
 
 :fire: **Updates:**
 - `2024/08/12`: We build smaller [VideoCLIP](./MODEL_ZOO.md) with MobileCLIP. Please download [InternVideo2-stage2-distil](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/stage1) and set `vision_ckpt_path` in `config.py`, [mobileclip_blt](https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/mobileclip_blt.pt) and set `text_ckpt_path` in `config.py`, and finally, download [InternVideo2-stage2-clip](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/clip) and set `extra_ckpt_path` in `config.py`.

--- a/InternVideo2/multi_modality/README.md
+++ b/InternVideo2/multi_modality/README.md
@@ -54,7 +54,7 @@ bash scripts/pretraining/clip/1B/run.sh
 3. Download [internvl_c_13b_224px](https://huggingface.co/OpenGVLab/InternVL/blob/main/internvl_c_13b_224px.pth) and set `text_ckpt_path` in `config.py`, you also need to set ,.
 
 :fire: **Updates:**
-- `2024/08/12`: We build smaller [VideoCLIP](./multi_modality/MODEL_ZOO.md) with MobileCLIP. Please download [InternVideo2-stage2-distil](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/stage1) and set `vision_ckpt_path` in `config.py`, [mobileclip_blt](https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/mobileclip_blt.pt) and set `text_ckpt_path` in `config.py`, and finally, download [InternVideo2-stage2-clip](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/clip) and set `extra_ckpt_path` in `config.py`.
+- `2024/08/12`: We build smaller [VideoCLIP](./MODEL_ZOO.md) with MobileCLIP. Please download [InternVideo2-stage2-distil](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/stage1) and set `vision_ckpt_path` in `config.py`, [mobileclip_blt](https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/mobileclip_blt.pt) and set `text_ckpt_path` in `config.py`, and finally, download [InternVideo2-stage2-clip](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/clip) and set `extra_ckpt_path` in `config.py`.
 
 
 ## Zero-shot Evaluation

--- a/InternVideo2/multi_modality/README.md
+++ b/InternVideo2/multi_modality/README.md
@@ -54,7 +54,7 @@ bash scripts/pretraining/clip/1B/run.sh
 3. Download [internvl_c_13b_224px](https://huggingface.co/OpenGVLab/InternVL/blob/main/internvl_c_13b_224px.pth) and set `text_ckpt_path` in `config.py`, you also need to set ,.
 
 :fire: **Updates:**
-- `2024/08/12`: We build smaller [VideoCLIP](./multi_modality/MODEL_ZOO.md) with MobileCLIP. Please download [InternVideo2-stage2-distil](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/stage1) and set `vision_ckpt_path` in `config.py`, [mobileclip_blt](https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/mobileclip_blt.pt) and set `text_ckpt_path` in `config.py`,
+- `2024/08/12`: We build smaller [VideoCLIP](./multi_modality/MODEL_ZOO.md) with MobileCLIP. Please download [InternVideo2-stage2-distil](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/stage1) and set `vision_ckpt_path` in `config.py`, [mobileclip_blt](https://docs-assets.developer.apple.com/ml-research/datasets/mobileclip/mobileclip_blt.pt) and set `text_ckpt_path` in `config.py`, and finally, download [InternVideo2-stage2-clip](https://huggingface.co/OpenGVLab/InternVideo2_distillation_models/tree/main/clip) and set `extra_ckpt_path` in `config.py`.
 
 
 ## Zero-shot Evaluation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo contains InternVideo series and related works in video foundation mode
 - `2024.08`: [InternVideo2-Stage3-8B](https://huggingface.co/OpenGVLab/InternVideo2-Chat-8B) and [InternVideo2-Stage3-8B-HD](https://huggingface.co/OpenGVLab/InternVideo2_chat_8B_HD) are released. 8B indicates the use of InternVideo2-1B and the 7B LLM.
 - `2024.07`: The video annotation for InternVid2 ([HuggingFace](https://huggingface.co/datasets/OpenGVLab/InternVideo2_Vid_Text)) is released.
 - `2024.06`: The full version of the video annotation (230M video-text pairs) for InternVid ([OpenDataLab](https://opendatalab.com/shepshep/InternVidFull) | [HuggingFace](https://huggingface.co/datasets/OpenGVLab/InternVid-Full)) is released.
-- `2024.04`: The [Checkpoints](https://huggingface.co/collections/OpenGVLab/internvideo2-6618ccb574bd2f91410df5cd) and scripts of InternVideo2 are released.
+- `2024.04`: The [Checkpoints](https://huggingface.co/collections/OpenGVLab/internvideo2-6618ccb574bd2f91410df5cd) and scripts for InternVideo2 are released.
 - `2024.03`: The [technical report](https://arxiv.org/abs/2403.15377) of InternVideo2 is released.
 - `2024.01`: [InternVid](Data/InternVid) (a video-text dataset for video understanding and generation) has been accepted for spotlight presentation of ICLR 2024.
 - `2023.07`: A **video-text dataset InternVid** is released at [here](Data/InternVid) for facilitating multimodal understanding and generation.


### PR DESCRIPTION
Add information about the small `clip` models in `README.md`. Hopefully this makes it clearer what these files actually do.

Edit: I also fixed a link in the InternVideo2 Readme.